### PR TITLE
Allow parameter properties

### DIFF
--- a/style.json
+++ b/style.json
@@ -10,7 +10,7 @@
     "interface-over-type-literal": true,
     "no-consecutive-blank-lines": [ true, 1 ],
     "no-irregular-whitespace": true,
-    "no-parameter-properties": true,
+    "no-parameter-properties": false,
     "no-trailing-whitespace": true,
     "one-variable-per-declaration": true,
     "ordered-imports": true,


### PR DESCRIPTION
That is, writing constructors like
```ts
class A {
  constructor(private someprop: string, public someOther: number) {
    // ...
  }
}
```

Rather than the much more verbose way:
```ts
class A {
  private someprop: string;
  public someOther: number;

  constructor(someprop: string, someOther: number) {
    this.someprop = someprop;
    this.someOther = someOther;

    // ...
  }
}
```